### PR TITLE
Use AppsCode Community License

### DIFF
--- a/Dockerfile.dbg
+++ b/Dockerfile.dbg
@@ -1,10 +1,10 @@
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,10 +1,10 @@
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,14 +1,5 @@
 ## License
 
-Source code in this repository is licensed under the PolyForm Noncommercial License 1.0.0. You may obtain a copy of the License at
+Source code in this repository, Binaries, Docker images and Charts produced by the build process are licensed under the AppsCode Community License 1.0.0. You may obtain a copy of the License at
 
- - [PolyForm-Noncommercial-1.0.0](https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md)
-
-Binaries, Docker images and Charts produced by the build process are dually licensed under the PolyForm Noncommercial License 1.0.0 and the AppsCode Free Trial License 1.0.0. You may obtain a copy of these Licenses at
-
- - [PolyForm-Noncommercial-1.0.0](https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md)
- - [AppsCode-Free-Trial-1.0.0](https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md)
-
-Documentation found under [docs](docs) directory is licensed under the Apache License, Version 2.0. You may obtain a copy of the License at
-
- - [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ - [AppsCode-Community-1.0.0](https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md)

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/api/crds/doc.go
+++ b/api/crds/doc.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/api/crds/lib.go
+++ b/api/crds/lib.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/apis/installer/fuzzer/fuzzer.go
+++ b/apis/installer/fuzzer/fuzzer.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/apis/installer/install/install.go
+++ b/apis/installer/install/install.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/apis/installer/install/pruning_test.go
+++ b/apis/installer/install/pruning_test.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/apis/installer/install/roundtrip_test.go
+++ b/apis/installer/install/roundtrip_test.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/apis/installer/register.go
+++ b/apis/installer/register.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/apis/installer/v1alpha1/doc.go
+++ b/apis/installer/v1alpha1/doc.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/apis/installer/v1alpha1/generated.pb.go
+++ b/apis/installer/v1alpha1/generated.pb.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/apis/installer/v1alpha1/generated.proto
+++ b/apis/installer/v1alpha1/generated.proto
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/apis/installer/v1alpha1/openapi_generated.go
+++ b/apis/installer/v1alpha1/openapi_generated.go
@@ -3,11 +3,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/apis/installer/v1alpha1/register.go
+++ b/apis/installer/v1alpha1/register.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/apis/installer/v1alpha1/stash_perconaxtradb_helpers.go
+++ b/apis/installer/v1alpha1/stash_perconaxtradb_helpers.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/apis/installer/v1alpha1/stash_perconaxtradb_types.go
+++ b/apis/installer/v1alpha1/stash_perconaxtradb_types.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/apis/installer/v1alpha1/stash_perconaxtradb_types_test.go
+++ b/apis/installer/v1alpha1/stash_perconaxtradb_types_test.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/apis/installer/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/installer/v1alpha1/zz_generated.deepcopy.go
@@ -3,11 +3,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/stash-percona-xtradb/main.go
+++ b/cmd/stash-percona-xtradb/main.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/stash-percona-xtradb/version.go
+++ b/cmd/stash-percona-xtradb/version.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -2,11 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/docker/stash-percona-xtradb/backup.sh
+++ b/hack/docker/stash-percona-xtradb/backup.sh
@@ -2,11 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/docker/stash-percona-xtradb/restore.sh
+++ b/hack/docker/stash-percona-xtradb/restore.sh
@@ -2,11 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -2,11 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/fmt.sh
+++ b/hack/fmt.sh
@@ -2,11 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/gencrd/main.go
+++ b/hack/gencrd/main.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/license/bash.txt
+++ b/hack/license/bash.txt
@@ -1,14 +1,13 @@
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/hack/license/dockerfile.txt
+++ b/hack/license/dockerfile.txt
@@ -1,10 +1,10 @@
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/license/go.txt
+++ b/hack/license/go.txt
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/license/makefile.txt
+++ b/hack/license/makefile.txt
@@ -1,10 +1,10 @@
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/scripts/cherry-pick.sh
+++ b/hack/scripts/cherry-pick.sh
@@ -2,11 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/scripts/update-release-tracker.sh
+++ b/hack/scripts/update-release-tracker.sh
@@ -2,11 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -2,11 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/backup.go
+++ b/pkg/backup.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/restore.go
+++ b/pkg/restore.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/root.go
+++ b/pkg/root.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -1,11 +1,11 @@
 /*
 Copyright AppsCode Inc. and Contributors
 
-Licensed under the PolyForm Noncommercial License 1.0.0 (the "License");
+Licensed under the AppsCode Community License 1.0.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This allows both commercial and non-commercial organizations use the Community Edition of this software.

/cherry-pick

Signed-off-by: Tamal Saha <tamal@appscode.com>